### PR TITLE
Add iterator product()

### DIFF
--- a/src/itertools.nim
+++ b/src/itertools.nim
@@ -382,6 +382,49 @@ iterator islice*[T](s: openArray[T], start = 0, stop = -1, step = 1): T =
     i += step
 
 
+iterator product*[T](s: openArray[seq[T]]): seq[T] =
+  ## Iterator which yields the Cartesian product of the sequences of `s`
+  ##
+  ## ::
+  ##     product([@["A","B","C"], @["x","y"]]) --> Ax Ay Bx By Cx Cy
+  ##
+  ## Currently, each sequence must contain the same type (i.e. all strings or all ints)
+  runnableExamples:
+    let
+      a = @["A", "B"]
+      b = @["x", "y"]
+    var
+      s1: seq[seq[string]] = @[]
+    
+    for x in product([a, b]):
+      s1.add(x)
+    doAssert s1 == @[@["A", "x"], @["A", "y"],
+                     @["B", "x"], @["B", "y"]] 
+  
+  var
+    counters: seq[int]
+    done = false
+  for channel in s:
+    counters.add(0)
+  
+  while not done:
+    var ret: seq[T]
+    for i, counter in counters:
+      ret.add(s[i][counter])
+    yield ret
+    var i = counters.len - 1
+    while true:
+      inc(counters[i])
+      if counters[i] >= s[i].len:
+        counters[i] = 0
+        dec(i)
+      else:
+        break
+      if i < 0:
+        done = true
+        break
+    
+
 iterator takeWhile*[T](s: openArray[T], f: proc(a: T): bool): T =
   ## Iterator which yields elements of `s` as long as predicate is true.
   runnableExamples:
@@ -413,7 +456,6 @@ iterator takeWhile*[T](s: openArray[T], f: proc(a: T): bool): T =
       break
 
 
-
 when isMainModule:
   # needed to run the tests in `runnableExamples`
   discard count(3)()
@@ -427,4 +469,5 @@ when isMainModule:
   for _ in filterFalse(@[1, 2], proc(a: int): bool = a < 0): break
   for _ in groupBy(@[1, 2], proc(x: int): bool = x mod 2 == 0): break
   for _ in islice(@[1, 2, 3], 2): break
+  for _ in product([@[1, 2], @[3, 4]]): break
   for _ in takeWhile(@[1, 2], proc(a: int): bool = a < 2): break


### PR DESCRIPTION
This adds an iterator version of product.  It's similar to [stdlib `algorithm.product`](https://nim-lang.org/docs/algorithm.html#product%2CopenArray%5Bseq%5BT%5D%5D) except that it's an iterator instead of a proc.

Limitations:

- I have no idea if it's efficient -- it could probably be improved
- It only works on same-typed sequences.  For instance, you can't do `product([@[1,2,3], @['a', 'b']])`

Do you want me to commit my changes to `docs/index.html`?  It includes this unrelated change:

```diff
diff --git a/docs/index.html b/docs/index.html
index 57d4866..49689e8 100644
--- a/docs/index.html
+++ b/docs/index.html
@@ -1238,12 +1238,6 @@ function main() {
     </select>
   </div>
   <ul class="simple simple-toc" id="toc-list">
-<li>
-  <a class="reference reference-toplevel" href="#6" id="56">Imports</a>
-  <ul class="simple simple-toc-section">
-    
-  </ul>
-</li>
 <li>
   <a class="reference reference-toplevel" href="#12" id="62">Procs</a>
   <ul class="simple simple-toc-section">
 
@@ -1289,12 +1285,7 @@ function main() {
   <div class="nine columns" id="content">
   <div id="tocRoot"></div>
   <p class="module-desc"></p>
-  <div class="section" id="6">
-<h1><a class="toc-backref" href="#6">Imports</a></h1>
-<dl class="item">
-<a class="reference external" href="tables.html">tables</a>
-</dl></div>
-<div class="section" id="12">
+  <div class="section" id="12">

```
