### PR TITLE
performance boost to unique

### DIFF
--- a/src/itertools.nim
+++ b/src/itertools.nim
@@ -1,6 +1,4 @@
-import algorithm
-import sets
-import tables
+import algorithm, sets, tables
 
 
 proc count*(start: SomeNumber): iterator(): SomeNumber =
@@ -675,12 +673,14 @@ iterator unique*[T](s: openArray[T]): T =
         s2.add(x)
       doAssert s1 == @['b', 'a', 'o']
       doAssert s2 == @[3, 4]
-        
+
   var seen = initSet[T]()
   for x in s:
     if x notin seen:
       seen.incl(x)
       yield x
+
+
 
 
 when isMainModule:

--- a/src/itertools.nim
+++ b/src/itertools.nim
@@ -1,4 +1,6 @@
-import algorithm, tables
+import algorithm
+import sets
+import tables
 
 
 proc count*(start: SomeNumber): iterator(): SomeNumber =
@@ -607,7 +609,6 @@ iterator combinations*[T](s: openArray[T], r: Positive): seq[T] =
     yield x
 
 
-
 iterator chunked*[T](s: openArray[T], size: Positive): seq[T] =
   ## Iterator which yields ``size``-sized chunks from ``s``.
   runnableExamples:
@@ -629,7 +630,6 @@ iterator chunked*[T](s: openArray[T], size: Positive): seq[T] =
     yield s[i ..< i+size]
     i += size
   yield s[i .. ^1]
-
 
 
 iterator windowed*[T](s: openArray[T], size: Positive): seq[T] =
@@ -676,13 +676,11 @@ iterator unique*[T](s: openArray[T]): T =
       doAssert s1 == @['b', 'a', 'o']
       doAssert s2 == @[3, 4]
         
-  var seen: seq[T] = @[]
+  var seen = initSet[T]()
   for x in s:
     if x notin seen:
-      seen.add(x)
+      seen.incl(x)
       yield x
-
-
 
 
 when isMainModule:


### PR DESCRIPTION
The current implementation of `unique` is not optimal. You use a `seq` for storing unique values, and the `in` operator does a full search on it every time. In a loop it's very slow. Remedy: replace `seq` with a `hashset`. A `hashset` uses hashing with the `in` operator, thus it's very fast.

Here is a performance comparison:

```nim
import times, os

import random

from itertools import unique    # your original implementation with seq
from uniq import unique2        # the new implementation with HashSet

randomize(42)

const
  N = 1_000_000
  MAX = 100

proc main() =
  var numbers = newSeq[int](N)
  for i in 0 .. numbers.high:
    numbers[i] = rand(0 .. MAX)
  
  var
    start: float
    stop: float
    res: int

  res = 0
  start = cpuTime()
  for n in unique(numbers):
    res = n
  stop = cpuTime()
  echo "Unique 1 elapsed time: ", stop - start

  res = 0
  start = cpuTime()
  for n in unique2(numbers):
    res = n
  stop = cpuTime()
  echo "Unique 2 elapsed time: ", stop - start

when isMainModule:
  main()
```

Runtimes:

Unique 1 elapsed time: 0.6664239999999999
Unique 2 elapsed time: 0.08060299999999998